### PR TITLE
Fix for pubDate formatting

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 version: 1.0.0.{build}.{branch}
 image: Visual Studio 2015
 
-before_build:
- - cmd: dotnet restore
+install:
+ - cmd: cd src && dotnet restore
 
 test_script:
- - cmd: dotnet test ./src/WilderMinds.RssSyndication.Tests
+ - cmd: dotnet test WilderMinds.RssSyndication.Tests
 

--- a/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
+++ b/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -99,6 +100,19 @@ namespace RssSyndication.Tests
       Assert.NotNull(item);
       Assert.True(item.Element("title").Value == "Foo Bar", "First Item was correct");
 
+    }
+
+    [Fact]
+    public void DatesAreProperlyFormatted()
+    {
+      CultureInfo.CurrentCulture = new CultureInfo("ru-RU");
+      var feed = CreateTestFeed();
+      var rss = feed.Serialize();
+      var doc = XDocument.Parse(rss);
+      var pubDate = doc.Descendants("pubDate").First();
+
+      var rfc822FormattedDate = feed.Items.First().PublishDate.ToString("r", CultureInfo.InvariantCulture);
+      Assert.Equal(rfc822FormattedDate, pubDate.Value);
     }
   }
 }

--- a/src/WilderMinds.RssSyndication/Feed.cs
+++ b/src/WilderMinds.RssSyndication/Feed.cs
@@ -37,7 +37,7 @@ namespace WilderMinds.RssSyndication
         foreach (var c in item.Categories) itemElement.Add(new XElement("category", c));
         if (item.Comments != null) itemElement.Add(new XElement("comments", item.Comments.AbsoluteUri));
         if (!string.IsNullOrWhiteSpace(item.Permalink)) itemElement.Add(new XElement("guid", item.Permalink));
-        var dateFmt = string.Concat(item.PublishDate.ToString("ddd',' d MMM yyyy HH':'mm':'ss"), " ", item.PublishDate.ToString("zzzz").Replace(":", ""));
+        var dateFmt = item.PublishDate.ToString("r");
         if (item.PublishDate != DateTime.MinValue) itemElement.Add(new XElement("pubDate", dateFmt));
         channel.Add(itemElement);
       }


### PR DESCRIPTION
Closes #2.

I've found that there's a wonderful RFC-compatible [`"r"` format specifier](https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#RFC1123) that is locale-independent and could be useful in this case.