### PR TITLE
Null object check, Intellisense summaries, and set method on Values property

### DIFF
--- a/src/WilderMinds.RssSyndication/Enclosure.cs
+++ b/src/WilderMinds.RssSyndication/Enclosure.cs
@@ -10,6 +10,6 @@ namespace WilderMinds.RssSyndication
       Values = new NameValueCollection();
     }
 
-    public NameValueCollection Values { get; }
+    public NameValueCollection Values { get; set; }
   }
 }

--- a/src/WilderMinds.RssSyndication/Feed.cs
+++ b/src/WilderMinds.RssSyndication/Feed.cs
@@ -5,6 +5,7 @@ using System.Xml.Linq;
 
 namespace WilderMinds.RssSyndication
 {
+  /// <summary>Feed object which maps to 'channel' property on Feed.Serialize()</summary>
   public class Feed
   {
     public string Description { get; set; }
@@ -14,6 +15,7 @@ namespace WilderMinds.RssSyndication
 
     public ICollection<Item> Items { get; set; } = new List<Item>();
 
+    /// <summary>Produces well-formatted rss-compatible xml string.</summary>
     public string Serialize()
     {
       var doc = new XDocument(new XElement("rss"));
@@ -21,7 +23,7 @@ namespace WilderMinds.RssSyndication
 
       var channel = new XElement("channel");
       channel.Add(new XElement("title", Title));
-      channel.Add(new XElement("link", Link.AbsoluteUri));
+      if (Link != null) channel.Add(new XElement("link", Link.AbsoluteUri));
       channel.Add(new XElement("description", Description));
       channel.Add(new XElement("copyright", Copyright));
       doc.Root.Add(channel);
@@ -30,7 +32,7 @@ namespace WilderMinds.RssSyndication
       {
         var itemElement = new XElement("item");
         itemElement.Add(new XElement("title", item.Title));
-        itemElement.Add(new XElement("link", item.Link.AbsoluteUri));
+        if (item.Link != null) itemElement.Add(new XElement("link", item.Link.AbsoluteUri));
         itemElement.Add(new XElement("description", item.Body));
         if (item.Author != null) itemElement.Add(new XElement("author", $"{item.Author.Email} ({item.Author.Name})"));
         foreach (var c in item.Categories) itemElement.Add(new XElement("category", c));

--- a/src/WilderMinds.RssSyndication/Item.cs
+++ b/src/WilderMinds.RssSyndication/Item.cs
@@ -11,7 +11,9 @@ namespace WilderMinds.RssSyndication
     public ICollection<string> Categories { get; set; } = new List<string>();
     public Uri Comments { get; set; }
     public Uri Link { get; set; }
+    /// <summary>Maps to 'guid' property on Feed.Serialize()</summary>
     public string Permalink { get; set; }
+    /// <summary>Maps to 'pubDate' property on Feed.Serialize()</summary>
     public DateTime PublishDate { get; set; }
     public string Title { get; set; }
     public ICollection<Enclosure> Enclosures { get; set; } = new List<Enclosure>();


### PR DESCRIPTION
Added a null object check in the `Feed.Serialize()` method for `Link` properties in order to avoid `Object reference not set to an instance of an object` errors. Added Intellisense summaries on select properties to identify the output property name on `Feed.Serialize()`. Also added a `set` method on the `Enclosure.Values` property to allow for easier dynamic population of the object.