### PR TITLE
Fix the NuGet version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Current Build Status: [![Build status](https://ci.appveyor.com/api/projects/stat
 
 Available as a Nuget Package for ASP.NET Core projects:
 
-- WilderMinds.RssSyndication 1.0.1
+- WilderMinds.RssSyndication [![NuGet](https://img.shields.io/nuget/v/WilderMinds.RssSyndication.svg)](https://www.nuget.org/packages/WilderMinds.RssSyndication)
 
 ## Example
 


### PR DESCRIPTION
This PR fixes the documentation. Added a badge for the NuGet to support dynamic versioning.
Let me know if we should style the `README` in a different way.