### PR TITLE
Fix a NullReferenceException if no Link is specified

### DIFF
--- a/src/WilderMinds.RssSyndication/Feed.cs
+++ b/src/WilderMinds.RssSyndication/Feed.cs
@@ -36,6 +36,8 @@ namespace WilderMinds.RssSyndication
                 new XAttribute(XNamespace.Xmlns + "atom", "http://www.w3.org/2005/Atom"));
 
         var channel = new XElement("channel");
+      	// ignore if Link is not specified to prevent a NullReferenceException
+        if (Link != null)
             channel.Add(
                 new XElement(nsAtom + "link",
                 new XAttribute("rel", "self"),


### PR DESCRIPTION
Null check to prevent a NullReferenceException if no value is specified for Link property.