### PR TITLE
Extra properties for Facebook and Flipboard

### DIFF
--- a/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
+++ b/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
@@ -12,7 +12,6 @@ namespace RssSyndication.Tests
 {
     public class FeedFacts
     {
-
         Feed CreateTestFeed()
         {
             var feed = new Feed
@@ -116,31 +115,30 @@ namespace RssSyndication.Tests
         }
 
         [Fact]
-    public void AtomIsSupported()
-    {
-      var feed = new Feed
-      {
-        Title = "Shawn Wildermuth's Blog",
-        Description = "My Favorite Rants and Raves",
-        Link = new Uri("http://wildermuth.com/feed")
-      };
+        public void AtomIsSupported()
+        {
+            var feed = new Feed
+            {
+                Title = "Shawn Wildermuth's Blog",
+                Description = "My Favorite Rants and Raves",
+                Link = new Uri("http://wildermuth.com/feed")
+            };
 
-      Assert.NotNull(feed);
-      Assert.Null(feed.Copyright);
-    }
+            Assert.NotNull(feed);
+            Assert.Null(feed.Copyright);
+        }
 
+        [Fact]
+        public void CopyrightIsOptional()
+        {
+            var feed = CreateTestFeed();
 
-    [Fact]
-    public void CopyrightIsOptional()
-    {
-      var feed = CreateTestFeed();
+            Assert.NotNull(feed);
+            var rss = feed.Serialize();
+            Assert.Contains("http://www.w3.org/2005/Atom", rss);
+        }
 
-      Assert.NotNull(feed);
-      var rss = feed.Serialize();
-      Assert.Contains("http://www.w3.org/2005/Atom", rss);
-    }
-
-    [Fact]
+        [Fact]
         public void GeneratedXmlContainsDeclaration()
         {
             var feed = CreateTestFeed();
@@ -148,18 +146,18 @@ namespace RssSyndication.Tests
             Assert.StartsWith("<?xml version", rss);
         }
 
-    [Fact]
-    public void GeneratedXmlHonorsSerializeOption()
-    {
-      var feed = CreateTestFeed();
+        [Fact]
+        public void GeneratedXmlHonorsSerializeOption()
+        {
+            var feed = CreateTestFeed();
 
-      var defaultRss = feed.Serialize();
-      var withOption = feed.Serialize(new SerializeOption() { Encoding = Encoding.UTF8 });
+            var defaultRss = feed.Serialize();
+            var withOption = feed.Serialize(new SerializeOption() { Encoding = Encoding.UTF8 });
 
-      // verify encoding
-      Assert.Contains("utf-16", new StringReader(defaultRss).ReadLine());
-      Assert.Contains("utf-8", new StringReader(withOption).ReadLine());
-}
+            // verify encoding
+            Assert.Contains("utf-16", new StringReader(defaultRss).ReadLine());
+            Assert.Contains("utf-8", new StringReader(withOption).ReadLine());
+        }
 
         [Fact]
         public void SerializedXmlHasContentNamespace()
@@ -183,8 +181,6 @@ namespace RssSyndication.Tests
 
             Assert.Contains("xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"", rss, StringComparison.OrdinalIgnoreCase);
         }
-  
-
 
         [Fact]
         public void HtmlContentIsEnclosedInCData()
@@ -218,7 +214,6 @@ namespace RssSyndication.Tests
 
             Assert.True(content.FirstNode.ToString().StartsWith("<![CDATA["), "HTML content needs to start with <![CDATA[");
         }
-
 
         [Fact]
         public void HtmlContentIsEnclosedInCData_Check2()
@@ -285,5 +280,4 @@ namespace RssSyndication.Tests
             Assert.DoesNotContain("&amp;", content.Value, StringComparison.OrdinalIgnoreCase);
         }
     }
-
 }

--- a/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
+++ b/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
@@ -120,6 +120,39 @@ namespace RssSyndication.Tests
             var rss = feed.Serialize();
             Assert.StartsWith("<?xml version", rss);
         }
+
+
+        [Fact]
+        public void HtmlContentIsEscaped()
+        {
+            var feed = CreateTestFeed();
+
+            feed.Items.Clear();
+            feed.Items.Add(new Item()
+            {
+                Title = "fake",
+                FullHtmlContent = "<header><h1>article title</h1></header><main><p>body with &lt; some html characters and some neat@no.com symbols.</p></main><footer>&copy; 2019</footer>",
+
+                Body = "<p>Foo bar</p>",
+                Link = new Uri("http://foobar.com/item#1"),
+                Permalink = "http://foobar.com/item#1",
+                PublishDate = DateTime.UtcNow,
+                Author = new Author { Name = "Shawn Wildermuth", Email = "shawn@wildermuth.com" }
+            });
+
+            var rss = feed.Serialize();
+            var doc = XDocument.Parse(rss);
+
+        //    XNamespace ns = new XNamespace("")
+          //  var content = doc.Descendants(("content:encoded").First();
+
+            XNamespace ns = doc.Root.GetNamespaceOfPrefix("content");
+
+            var content = doc.Descendants(XNamespace.Get("content") + "encoded").First();
+
+            Assert.NotNull(content);
+
+        }
     }
 
 }

--- a/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
+++ b/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
@@ -137,21 +137,20 @@ namespace RssSyndication.Tests
                 Link = new Uri("http://foobar.com/item#1"),
                 Permalink = "http://foobar.com/item#1",
                 PublishDate = DateTime.UtcNow,
-                Author = new Author { Name = "Shawn Wildermuth", Email = "shawn@wildermuth.com" }
+                Author = new Author { Name = "Dirk Watkins", Email = "ya@right.dev" }
             });
 
             var rss = feed.Serialize();
+
+            Assert.Contains("xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"", rss, StringComparison.OrdinalIgnoreCase);
+
             var doc = XDocument.Parse(rss);
-
-        //    XNamespace ns = new XNamespace("")
-          //  var content = doc.Descendants(("content:encoded").First();
-
-            XNamespace ns = doc.Root.GetNamespaceOfPrefix("content");
 
             var content = doc.Descendants(XNamespace.Get("content") + "encoded").First();
 
             Assert.NotNull(content);
 
+            Assert.True(content.Value.StartsWith("<![CDATA["), "HTML content needs to start with <![CDATA[");
         }
     }
 

--- a/src/WilderMinds.RssSyndication.Tests/Properties/launchSettings.json
+++ b/src/WilderMinds.RssSyndication.Tests/Properties/launchSettings.json
@@ -9,7 +9,7 @@
   },
   "profiles": {
     "IIS Express": {
-      "commandName": "IISExpress",
+      "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/WilderMinds.RssSyndication.Tests/WilderMinds.RssSyndication.Tests.csproj
+++ b/src/WilderMinds.RssSyndication.Tests/WilderMinds.RssSyndication.Tests.csproj
@@ -15,6 +15,9 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <ApplicationIcon />
+    <OutputType>Library</OutputType>
+    <StartupObject></StartupObject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WilderMinds.RssSyndication/Author.cs
+++ b/src/WilderMinds.RssSyndication/Author.cs
@@ -2,9 +2,9 @@
 
 namespace WilderMinds.RssSyndication
 {
-  public class Author
-  {
-    public string Name { get; set; }
-    public string Email { get; set; }
-  }
+    public class Author
+    {
+        public string Name { get; set; }
+        public string Email { get; set; }
+    }
 }

--- a/src/WilderMinds.RssSyndication/Enclosure.cs
+++ b/src/WilderMinds.RssSyndication/Enclosure.cs
@@ -1,15 +1,31 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 
 namespace WilderMinds.RssSyndication
 {
-  public class Enclosure
-  {
-    public Enclosure()
+    public class Enclosure
     {
-      Values = new NameValueCollection();
-    }
+        public Enclosure()
+        {
+            Values = new NameValueCollection();
+        }
+        /// <summary>
+        /// Absolute URL to where the enclosure is located
+        /// </summary>
+        public Uri Url { get; set; }
 
-    public NameValueCollection Values { get; set; }
-  }
+        /// <summary>
+        /// Size in Bytes
+        /// </summary>
+        public int Length { get; set; }
+
+        /// <summary>
+        /// standard MIME type
+        /// </summary>
+        /// <example>audtio/mpeg</example>
+        public string MimeType { get; set; }
+
+        public NameValueCollection Values { get; set; }
+    }
 }

--- a/src/WilderMinds.RssSyndication/Enclosure.cs
+++ b/src/WilderMinds.RssSyndication/Enclosure.cs
@@ -23,7 +23,7 @@ namespace WilderMinds.RssSyndication
         /// <summary>
         /// standard MIME type
         /// </summary>
-        /// <example>audtio/mpeg</example>
+        /// <example>audio/mpeg</example>
         public string MimeType { get; set; }
 
         public NameValueCollection Values { get; set; }

--- a/src/WilderMinds.RssSyndication/Feed.cs
+++ b/src/WilderMinds.RssSyndication/Feed.cs
@@ -25,11 +25,13 @@ namespace WilderMinds.RssSyndication
         /// <summary>Produces well-formatted rss-compatible xml string.</summary>
         public string Serialize()
         {
+            var contentNamespaceUrl = "http://purl.org/rss/1.0/modules/content/";
+
             var doc = new XDocument(new XElement("rss"));
             doc.Root.Add(new XAttribute("version", "2.0"));
-          //  XNamespace nsContent = "http://purl.org/rss/1.0/modules/content/";
 
-            doc.Root.Add(new XAttribute(XNamespace.Xmlns + "content", "http://purl.org/rss/1.0/modules/content/"));
+            //namespace for Facebook's xmlns:content full article content area
+            doc.Root.Add(new XAttribute(XNamespace.Xmlns + "content", contentNamespaceUrl));
 
             var channel = new XElement("channel");
             channel.Add(new XElement("title", Title));
@@ -57,7 +59,7 @@ namespace WilderMinds.RssSyndication
                 if (item.Comments != null) itemElement.Add(new XElement("comments", item.Comments.AbsoluteUri));
 
                 if (!string.IsNullOrWhiteSpace(item.Permalink)) itemElement.Add(new XElement("guid", item.Permalink));
-              
+
                 var dateFmt = item.PublishDate.ToString("r");
                 if (item.PublishDate != DateTime.MinValue) itemElement.Add(new XElement("pubDate", dateFmt));
 
@@ -91,21 +93,20 @@ namespace WilderMinds.RssSyndication
 
                 if (!string.IsNullOrWhiteSpace(item.FullHtmlContent))
                 {
-                      //   XNamespace ns = doc.Root.GetNamespaceOfPrefix("content");
-
-                    var html = new XElement(XNamespace.Get("content") + "encoded",
-                        "<![CDATA[" + 
-                        item.FullHtmlContent + 
-                        "]]>"
-                        );               
+                    //add content:encoded element, CData escaped html
+                    var ns = XNamespace.Get(contentNamespaceUrl);
+                    var html = new XElement(ns + "encoded", new XCData(item.FullHtmlContent));                    
                     itemElement.Add(html);
+                    html.ReplaceNodes(new XCData(item.FullHtmlContent));
                 }
 
 
                 channel.Add(itemElement);
             }
 
-            return doc.ToStringWithDeclaration();
+            string result =  doc.ToStringWithDeclaration();
+
+            return result;
         }
     }
 }

--- a/src/WilderMinds.RssSyndication/Feed.cs
+++ b/src/WilderMinds.RssSyndication/Feed.cs
@@ -23,49 +23,50 @@ namespace WilderMinds.RssSyndication
 
         public ICollection<Item> Items { get; set; } = new List<Item>();
 
-    /// <summary>Produces well-formatted rss-compatible xml string.</summary>
-    public string Serialize()
-    {
+        /// <summary>Produces well-formatted rss-compatible xml string.</summary>
+        public string Serialize()
+        {
 
-      var defaultOption = new SerializeOption()
-      {
-        Encoding = Encoding.Unicode
-      };
-      return Serialize(defaultOption);
-    }
-    /// <summary>Produces well-formatted rss-compatible xml string.</summary>
-    public string Serialize(SerializeOption option)
-    {
- var contentNamespaceUrl = "http://purl.org/rss/1.0/modules/content/";
+            var defaultOption = new SerializeOption()
+            {
+                Encoding = Encoding.Unicode
+            };
+            return Serialize(defaultOption);
+        }
 
-        XNamespace nsAtom = "http://www.w3.org/2005/Atom";
-        var doc = new XDocument(new XElement("rss"));
+        /// <summary>Produces well-formatted rss-compatible xml string.</summary>
+        public string Serialize(SerializeOption option)
+        {
+            var contentNamespaceUrl = "http://purl.org/rss/1.0/modules/content/";
 
-        doc.Root.Add(
-                new XAttribute("version", "2.0"), 
-                new XAttribute(XNamespace.Xmlns + "atom", "http://www.w3.org/2005/Atom"));
+            XNamespace nsAtom = "http://www.w3.org/2005/Atom";
+            var doc = new XDocument(new XElement("rss"));
+
+            doc.Root.Add(
+                    new XAttribute("version", "2.0"),
+                    new XAttribute(XNamespace.Xmlns + "atom", "http://www.w3.org/2005/Atom"));
 
             //namespace for Facebook's xmlns:content full article content area
             doc.Root.Add(new XAttribute(XNamespace.Xmlns + "content", contentNamespaceUrl));
 
-        var channel = new XElement("channel");
-      	// ignore if Link is not specified to prevent a NullReferenceException
-        if (Link != null)
-            channel.Add(
-                new XElement(nsAtom + "link",
-                new XAttribute("rel", "self"),
-                new XAttribute("type","application/rss+xml"),
-                new XAttribute("href", Link.AbsoluteUri)));
+            var channel = new XElement("channel");
+            // ignore if Link is not specified to prevent a NullReferenceException
+            if (Link != null)
+                channel.Add(
+                    new XElement(nsAtom + "link",
+                    new XAttribute("rel", "self"),
+                    new XAttribute("type", "application/rss+xml"),
+                    new XAttribute("href", Link.AbsoluteUri)));
 
             channel.Add(new XElement("title", Title));
             if (Link != null) channel.Add(new XElement("link", Link.AbsoluteUri));
             channel.Add(new XElement("description", Description));
             // copyright is not a requirement
             if (!string.IsNullOrEmpty(Copyright)) channel.Add(new XElement("copyright", Copyright));
-        
+
             channel.Add(new XElement("language", Language));
 
-        doc.Root.Add(channel);
+            doc.Root.Add(channel);
 
             foreach (var item in Items)
             {
@@ -120,16 +121,15 @@ namespace WilderMinds.RssSyndication
                 {
                     //add content:encoded element, CData escaped html
                     var ns = XNamespace.Get(contentNamespaceUrl);
-                    var html = new XElement(ns + "encoded", new XCData(item.FullHtmlContent));                    
+                    var html = new XElement(ns + "encoded", new XCData(item.FullHtmlContent));
                     itemElement.Add(html);
                     html.ReplaceNodes(new XCData(item.FullHtmlContent));
                 }
 
-
                 channel.Add(itemElement);
             }
 
-      return doc.ToStringWithDeclaration(option);
+            return doc.ToStringWithDeclaration(option);
         }
     }
 }

--- a/src/WilderMinds.RssSyndication/Feed.cs
+++ b/src/WilderMinds.RssSyndication/Feed.cs
@@ -5,58 +5,100 @@ using System.Xml.Linq;
 
 namespace WilderMinds.RssSyndication
 {
-  /// <summary>Feed object which maps to 'channel' property on Feed.Serialize()</summary>
-  public class Feed
-  {
-    public string Description { get; set; }
-    public Uri Link { get; set; }
-    public string Title { get; set; }
-    public string Copyright { get; set; }
-
-    public ICollection<Item> Items { get; set; } = new List<Item>();
-
-    /// <summary>Produces well-formatted rss-compatible xml string.</summary>
-    public string Serialize()
+    /// <summary>Feed object which maps to 'channel' property on Feed.Serialize()</summary>
+    public class Feed
     {
-      var doc = new XDocument(new XElement("rss"));
-      doc.Root.Add(new XAttribute("version", "2.0"));
+        public string Description { get; set; }
+        public Uri Link { get; set; }
+        public string Title { get; set; }
+        public string Copyright { get; set; }
 
-      var channel = new XElement("channel");
-      channel.Add(new XElement("title", Title));
-      if (Link != null) channel.Add(new XElement("link", Link.AbsoluteUri));
-      channel.Add(new XElement("description", Description));
-      channel.Add(new XElement("copyright", Copyright));
-      doc.Root.Add(channel);
+        /// <summary>
+        /// ISO-639 language codes.
+        /// </summary>
+        /// <example>en</example>
+        /// <remarks>https://www.loc.gov/standards/iso639-2/php/code_list.php</remarks>
+        public string Language { get; set; } = "en";
 
-      foreach (var item in Items)
-      {
-        var itemElement = new XElement("item");
-        itemElement.Add(new XElement("title", item.Title));
-        if (item.Link != null) itemElement.Add(new XElement("link", item.Link.AbsoluteUri));
-        itemElement.Add(new XElement("description", item.Body));
-        if (item.Author != null) itemElement.Add(new XElement("author", $"{item.Author.Email} ({item.Author.Name})"));
-        foreach (var c in item.Categories) itemElement.Add(new XElement("category", c));
-        if (item.Comments != null) itemElement.Add(new XElement("comments", item.Comments.AbsoluteUri));
-        if (!string.IsNullOrWhiteSpace(item.Permalink)) itemElement.Add(new XElement("guid", item.Permalink));
-        var dateFmt = item.PublishDate.ToString("r");
-        if (item.PublishDate != DateTime.MinValue) itemElement.Add(new XElement("pubDate", dateFmt));
-        if (item.Enclosures != null && item.Enclosures.Any())
+        public ICollection<Item> Items { get; set; } = new List<Item>();
+
+        /// <summary>Produces well-formatted rss-compatible xml string.</summary>
+        public string Serialize()
         {
-          foreach (var enclosure in item.Enclosures)
-          {
-            var enclosureElement = new XElement("enclosure");
-            foreach (var key in enclosure.Values.AllKeys)
+            var doc = new XDocument(new XElement("rss"));
+            doc.Root.Add(new XAttribute("version", "2.0"));
+
+            var channel = new XElement("channel");
+            channel.Add(new XElement("title", Title));
+            if (Link != null) channel.Add(new XElement("link", Link.AbsoluteUri));
+            channel.Add(new XElement("description", Description));
+            channel.Add(new XElement("copyright", Copyright));
+            channel.Add(new XElement("language", Language));
+
+            doc.Root.Add(channel);
+
+            foreach (var item in Items)
             {
-              enclosureElement.Add(new XAttribute(key, enclosure.Values[key]));
+                var itemElement = new XElement("item");
+
+                itemElement.Add(new XElement("title", item.Title));
+
+                if (item.Link != null) itemElement.Add(new XElement("link", item.Link.AbsoluteUri));
+
+                itemElement.Add(new XElement("description", item.Body));
+
+                if (item.Author != null) itemElement.Add(new XElement("author", $"{item.Author.Email} ({item.Author.Name})"));
+
+                foreach (var c in item.Categories) itemElement.Add(new XElement("category", c));
+
+                if (item.Comments != null) itemElement.Add(new XElement("comments", item.Comments.AbsoluteUri));
+
+                if (!string.IsNullOrWhiteSpace(item.Permalink)) itemElement.Add(new XElement("guid", item.Permalink));
+              
+                var dateFmt = item.PublishDate.ToString("r");
+                if (item.PublishDate != DateTime.MinValue) itemElement.Add(new XElement("pubDate", dateFmt));
+
+                if (item.Enclosures != null && item.Enclosures.Any())
+                {
+                    foreach (var enclosure in item.Enclosures)
+                    {
+                        var enclosureElement = new XElement("enclosure");
+                        if (enclosure.Length > 0)
+                        {
+                            enclosureElement.Add(new XAttribute("length", enclosure.Length));
+                        }
+
+                        if (enclosure.Url != null)
+                        {
+                            enclosureElement.Add(new XAttribute("url", enclosure.Url.AbsoluteUri));
+                        }
+
+                        if (!string.IsNullOrWhiteSpace(enclosure.MimeType))
+                        {
+                            enclosureElement.Add(new XAttribute("type", enclosure.MimeType.Trim()));
+                        }
+
+                        foreach (var key in enclosure.Values.AllKeys)
+                        {
+                            enclosureElement.Add(new XAttribute(key, enclosure.Values[key]));
+                        }
+                        itemElement.Add(enclosureElement);
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(item.FullHtmlContent))
+                {
+                      //   XNamespace ns = doc.Root.GetNamespaceOfPrefix("content");
+
+                    var html = new XElement(XNamespace.Get("content") + "encoded", item.FullHtmlContent);               
+                    itemElement.Add(html);
+                }
+
+
+                channel.Add(itemElement);
             }
-            itemElement.Add(enclosureElement);
-          }
 
+            return doc.ToStringWithDeclaration();
         }
-        channel.Add(itemElement);
-      }
-
-      return doc.ToStringWithDeclaration();
     }
-  }
 }

--- a/src/WilderMinds.RssSyndication/Feed.cs
+++ b/src/WilderMinds.RssSyndication/Feed.cs
@@ -27,6 +27,9 @@ namespace WilderMinds.RssSyndication
         {
             var doc = new XDocument(new XElement("rss"));
             doc.Root.Add(new XAttribute("version", "2.0"));
+          //  XNamespace nsContent = "http://purl.org/rss/1.0/modules/content/";
+
+            doc.Root.Add(new XAttribute(XNamespace.Xmlns + "content", "http://purl.org/rss/1.0/modules/content/"));
 
             var channel = new XElement("channel");
             channel.Add(new XElement("title", Title));
@@ -90,7 +93,11 @@ namespace WilderMinds.RssSyndication
                 {
                       //   XNamespace ns = doc.Root.GetNamespaceOfPrefix("content");
 
-                    var html = new XElement(XNamespace.Get("content") + "encoded", item.FullHtmlContent);               
+                    var html = new XElement(XNamespace.Get("content") + "encoded",
+                        "<![CDATA[" + 
+                        item.FullHtmlContent + 
+                        "]]>"
+                        );               
                     itemElement.Add(html);
                 }
 

--- a/src/WilderMinds.RssSyndication/Item.cs
+++ b/src/WilderMinds.RssSyndication/Item.cs
@@ -1,33 +1,38 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Xml.Linq;
 
 namespace WilderMinds.RssSyndication
 {
     public class Item
     {
         public Author Author { get; set; }
+
         public string Body { get; set; }
+
         public ICollection<string> Categories { get; set; } = new List<string>();
+
         public Uri Comments { get; set; }
+
         public Uri Link { get; set; }
+
         /// <summary>Maps to 'guid' property on Feed.Serialize()</summary>
         public string Permalink { get; set; }
+
         /// <summary>Maps to 'pubDate' property on Feed.Serialize()</summary>
         public DateTime PublishDate { get; set; }
+
         public string Title { get; set; }
 
         /// <summary>
         /// The full content of your article, in HTML form.
         /// Mainly for Facebook feeds.  Insert the entire HTML content here.  It will be escaped in a CDATA section when serialized.
         /// </summary>
-        public string FullHtmlContent {get;set;}
+        public string FullHtmlContent { get; set; }
 
         /// <summary>
         /// A string that provides a unique identifier for this article in your feed.
         /// </summary>
-        public string Guid{get;set;}
-
+        public string Guid { get; set; }
 
         /// <summary>
         /// use this tag to add a media element that will be used in layout view to illustrate your article. 

--- a/src/WilderMinds.RssSyndication/Item.cs
+++ b/src/WilderMinds.RssSyndication/Item.cs
@@ -4,18 +4,36 @@ using System.Xml.Linq;
 
 namespace WilderMinds.RssSyndication
 {
-  public class Item
-  {
-    public Author Author { get; set; }
-    public string Body { get; set; }
-    public ICollection<string> Categories { get; set; } = new List<string>();
-    public Uri Comments { get; set; }
-    public Uri Link { get; set; }
-    /// <summary>Maps to 'guid' property on Feed.Serialize()</summary>
-    public string Permalink { get; set; }
-    /// <summary>Maps to 'pubDate' property on Feed.Serialize()</summary>
-    public DateTime PublishDate { get; set; }
-    public string Title { get; set; }
-    public ICollection<Enclosure> Enclosures { get; set; } = new List<Enclosure>();
-  }
+    public class Item
+    {
+        public Author Author { get; set; }
+        public string Body { get; set; }
+        public ICollection<string> Categories { get; set; } = new List<string>();
+        public Uri Comments { get; set; }
+        public Uri Link { get; set; }
+        /// <summary>Maps to 'guid' property on Feed.Serialize()</summary>
+        public string Permalink { get; set; }
+        /// <summary>Maps to 'pubDate' property on Feed.Serialize()</summary>
+        public DateTime PublishDate { get; set; }
+        public string Title { get; set; }
+
+        /// <summary>
+        /// The full content of your article, in HTML form.
+        /// Mainly for Facebook feeds.  Insert the entire HTML content here.  It will be escaped in a CDATA section when serialized.
+        /// </summary>
+        public string FullHtmlContent {get;set;}
+
+        /// <summary>
+        /// A string that provides a unique identifier for this article in your feed.
+        /// </summary>
+        public string Guid{get;set;}
+
+
+        /// <summary>
+        /// use this tag to add a media element that will be used in layout view to illustrate your article. 
+        /// It can be an image or a video. For videos, mobile-friendly mp4 format is strongly preferred. 
+        /// For images, prefer a high-resolution image; the smallest dimension should not be under 500px.
+        /// </summary>
+        public ICollection<Enclosure> Enclosures { get; set; } = new List<Enclosure>();
+    }
 }

--- a/src/WilderMinds.RssSyndication/XDocumentExtensions.cs
+++ b/src/WilderMinds.RssSyndication/XDocumentExtensions.cs
@@ -16,18 +16,18 @@ namespace WilderMinds.RssSyndication
             using (TextWriter writer = new RssStringWriter(builder, option))
                 what.Save(writer);
             return builder.ToString();
-            }
-        }
-
-        internal class RssStringWriter : StringWriter
-        {
-            private readonly SerializeOption option;
-
-            public RssStringWriter(StringBuilder sb, SerializeOption option) : base(sb)
-            {
-                this.option = option;
-            }
-
-            public override Encoding Encoding => option.Encoding;
         }
     }
+
+    internal class RssStringWriter : StringWriter
+    {
+        private readonly SerializeOption option;
+
+        public RssStringWriter(StringBuilder sb, SerializeOption option) : base(sb)
+        {
+            this.option = option;
+        }
+
+        public override Encoding Encoding => option.Encoding;
+    }
+}


### PR DESCRIPTION
Flipboard and Facebook have some special RSS properties that enhance the feed display on those platforms. Adding these fields to the serialization.

Example for Facebook:
https://developers.facebook.com/docs/instant-articles/publishing/setup-rss-feed

Example for Flipboard:
https://about.flipboard.com/rss-spec/