### PR TITLE
Add Image element support

### DIFF
--- a/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
+++ b/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
@@ -22,6 +22,8 @@ namespace RssSyndication.Tests
                 Copyright = "(c) 2016"
             };
 
+            feed.Image = new Image(new Uri("https://foobar.com/img/favicon.png"), feed.Title, feed.Link);
+
             var item1 = new Item
             {
                 Title = "Foo Bar",
@@ -140,6 +142,34 @@ namespace RssSyndication.Tests
 
             Assert.NotNull(feed);
             Assert.Null(feed.Image);
+        }
+
+        [Fact]
+        public void GeneratedXmlContainsImageElement()
+        {
+            var feed = CreateTestFeed();
+
+            Assert.NotNull(feed);
+            var rss = feed.Serialize();
+            Assert.Contains("<image>", rss);
+        }
+
+        [Fact]
+        public void GeneratedXmlContainsRequiredImageSubElements()
+        {
+            var feed = CreateTestFeed();
+            var rss = feed.Serialize();
+
+            const string imageTag = "<image>";
+            var imageContentStart = rss.IndexOf(imageTag, StringComparison.OrdinalIgnoreCase) +
+                                    imageTag.Length;
+            var imageContentEnd = rss.IndexOf("</image>", StringComparison.OrdinalIgnoreCase);
+
+            var imageSubElements =
+                rss.Substring(imageContentStart, imageContentEnd - imageContentStart);
+            Assert.Contains("<url>https://foobar.com/img/favicon.png", imageSubElements);
+            Assert.Contains("<title>Shawn Wildermuth's Blog", imageSubElements);
+            Assert.Contains("<link>http://wildermuth.com/feed", imageSubElements);
         }
 
         [Fact]

--- a/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
+++ b/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
@@ -115,7 +115,7 @@ namespace RssSyndication.Tests
         }
 
         [Fact]
-        public void AtomIsSupported()
+        public void CopyrightIsOptional()
         {
             var feed = new Feed
             {
@@ -129,7 +129,7 @@ namespace RssSyndication.Tests
         }
 
         [Fact]
-        public void CopyrightIsOptional()
+        public void AtomIsSupported()
         {
             var feed = CreateTestFeed();
 

--- a/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
+++ b/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
@@ -129,6 +129,20 @@ namespace RssSyndication.Tests
         }
 
         [Fact]
+        public void ImageIsOptional()
+        {
+            var feed = new Feed
+            {
+                Title = "Shawn Wildermuth's Blog",
+                Description = "My Favorite Rants and Raves",
+                Link = new Uri("http://wildermuth.com/feed")
+            };
+
+            Assert.NotNull(feed);
+            Assert.Null(feed.Image);
+        }
+
+        [Fact]
         public void AtomIsSupported()
         {
             var feed = CreateTestFeed();

--- a/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
+++ b/src/WilderMinds.RssSyndication.Tests/FeedFacts.cs
@@ -155,6 +155,17 @@ namespace RssSyndication.Tests
         }
 
         [Fact]
+        public void ShouldThrowIfRequiredSubElementsOfImageIsNull()
+        {
+            var url = new Uri("https://foobar.com/img/favicon.png");
+            var title = "Shawn Wildermuth's Blog";
+            var link = new Uri("http://wildermuth.com/feed");
+            Assert.Throws<ArgumentNullException>(() => new Image(null, title, link));
+            Assert.Throws<ArgumentNullException>(() => new Image(url, null, link));
+            Assert.Throws<ArgumentNullException>(() => new Image(url, title, null));
+        }
+
+        [Fact]
         public void GeneratedXmlContainsRequiredImageSubElements()
         {
             var feed = CreateTestFeed();

--- a/src/WilderMinds.RssSyndication/Feed.cs
+++ b/src/WilderMinds.RssSyndication/Feed.cs
@@ -67,6 +67,11 @@ namespace WilderMinds.RssSyndication
 
       channel.Add(new XElement("language", Language));
 
+      if (Image != null)
+      {
+          AddImageElement(channel);
+      }
+
       doc.Root.Add(channel);
 
       foreach (var item in Items)
@@ -131,6 +136,15 @@ namespace WilderMinds.RssSyndication
       }
 
       return doc.ToStringWithDeclaration(option);
+    }
+
+    private void AddImageElement(XElement channel)
+    {
+        var imageElement = new XElement("image");
+        imageElement.Add(new XElement("url", Image.Url.AbsoluteUri));
+        imageElement.Add(new XElement("title", Image.Title));
+        imageElement.Add(new XElement("link", Image.Link.AbsoluteUri));
+        channel.Add(imageElement);
     }
   }
 }

--- a/src/WilderMinds.RssSyndication/Feed.cs
+++ b/src/WilderMinds.RssSyndication/Feed.cs
@@ -13,6 +13,8 @@ namespace WilderMinds.RssSyndication
     public Uri Link { get; set; }
     public string Title { get; set; }
     public string Copyright { get; set; }
+
+    /// <summary>Optional element specifying an image that can be displayed with the channel.</summary>
     public Image Image { get; set; }
 
     /// <summary>

--- a/src/WilderMinds.RssSyndication/Feed.cs
+++ b/src/WilderMinds.RssSyndication/Feed.cs
@@ -13,6 +13,7 @@ namespace WilderMinds.RssSyndication
     public Uri Link { get; set; }
     public string Title { get; set; }
     public string Copyright { get; set; }
+    public Image Image { get; set; }
 
     /// <summary>
     /// ISO-639 language codes.

--- a/src/WilderMinds.RssSyndication/Image.cs
+++ b/src/WilderMinds.RssSyndication/Image.cs
@@ -6,6 +6,8 @@ namespace WilderMinds.RssSyndication
 {
     public class Image
     {
+        /// <summary>Image contains three required sub-elements: url, title and link.</summary>
+        /// <exception cref="ArgumentNullException">If any required sub-elements are null.</exception>
         public Image(Uri url, string title, Uri link)
         {
             Url = url ?? throw new ArgumentNullException(nameof(url));

--- a/src/WilderMinds.RssSyndication/Image.cs
+++ b/src/WilderMinds.RssSyndication/Image.cs
@@ -6,5 +6,15 @@ namespace WilderMinds.RssSyndication
 {
     public class Image
     {
+        public Image(Uri url, string title, Uri link)
+        {
+            Url = url;
+            Title = title;
+            Link = link;
+        }
+
+        public Uri Url { get; }
+        public string Title { get; }
+        public Uri Link { get; }
     }
 }

--- a/src/WilderMinds.RssSyndication/Image.cs
+++ b/src/WilderMinds.RssSyndication/Image.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WilderMinds.RssSyndication
+{
+    public class Image
+    {
+    }
+}

--- a/src/WilderMinds.RssSyndication/Image.cs
+++ b/src/WilderMinds.RssSyndication/Image.cs
@@ -8,13 +8,22 @@ namespace WilderMinds.RssSyndication
     {
         public Image(Uri url, string title, Uri link)
         {
-            Url = url;
-            Title = title;
-            Link = link;
+            Url = url ?? throw new ArgumentNullException(nameof(url));
+            Title = title ?? throw new ArgumentNullException(nameof(title));
+            Link = link ?? throw new ArgumentNullException(nameof(link));
         }
 
+        /// <summary>The URL of a GIF, JPEG or PNG image that represents the channel.</summary>
         public Uri Url { get; }
+
+        /// <summary>
+        /// Image description used in ALT attribute of the HTML image tag when the channel is rendered in HTML.
+        /// </summary>
         public string Title { get; }
+
+        /// <summary>
+        /// The URL of the site. When the channel is rendered, the image is a link to the site.
+        /// </summary>
         public Uri Link { get; }
     }
 }


### PR DESCRIPTION
Added the three required sub-elements of the optional Image element with related unit tests.

There are three optional sub-elements that could be added in the future if required: width, height and description.
Implementation based on [w3 specification](https://validator.w3.org/feed/docs/rss2.html#ltimagegtSubelementOfLtchannelgt).

Also a renaming of two existing unit test names that looked like they were mixed up ("AtomIsSupported" and "CopyrightIsOptional").
